### PR TITLE
DAG-1628 Fix patch unconfigurable in Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.1 - 2022-02-11
+- Fix create patch not configurable in Linux
+
 ## 0.2.0 - 2022-02-04
 - 'pull-request' subcommand will now default to '--fill' and validate arguments.
 - 'pull-request' will only add comments if there are multiple PRs being created.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evg-module-manager"
-version = "0.2.0"
+version = "0.2.1"
 description = "Manage Evergreen modules locally."
 authors = ["Dev Prod DAG <dev-prod-dag@mongodb.com>"]
 license = "Apache-2.0"

--- a/src/emm/services/patch_service.py
+++ b/src/emm/services/patch_service.py
@@ -49,7 +49,6 @@ class PatchService:
                     base_patch.patch_id, module, module_location, extra_args
                 )
 
-        self.evg_cli_service.finalize_patch(base_patch.patch_id)
         return base_patch
 
     def create_cq_patch(self, extra_args: List[str]) -> PatchInfo:

--- a/tests/emm/services/test_patch_service.py
+++ b/tests/emm/services/test_patch_service.py
@@ -55,7 +55,6 @@ class TestCreatePatch:
         patch_info = patch_service.create_patch([])
 
         assert patch_info == evg_cli_service.create_patch.return_value
-        evg_cli_service.finalize_patch.assert_called_with(patch_info.patch_id)
         evg_cli_service.add_module_to_patch.assert_not_called()
 
     def test_a_patch_with_no_enabled_modules_should_be_created_and_finalized(
@@ -69,7 +68,6 @@ class TestCreatePatch:
         patch_info = patch_service.create_patch([])
 
         assert patch_info == evg_cli_service.create_patch.return_value
-        evg_cli_service.finalize_patch.assert_called_with(patch_info.patch_id)
         evg_cli_service.add_module_to_patch.assert_not_called()
 
     def test_a_patch_with_enabled_modules_should_be_created_and_finalized(
@@ -83,7 +81,6 @@ class TestCreatePatch:
         patch_info = patch_service.create_patch([])
 
         assert patch_info == evg_cli_service.create_patch.return_value
-        evg_cli_service.finalize_patch.assert_called_with(patch_info.patch_id)
         assert 3 == evg_cli_service.add_module_to_patch.call_count
 
     def test_patches_should_pass_along_extra_args(
@@ -99,7 +96,6 @@ class TestCreatePatch:
 
         assert patch_info == evg_cli_service.create_patch.return_value
         evg_cli_service.create_patch.assert_called_with(extra_args)
-        evg_cli_service.finalize_patch.assert_called_with(patch_info.patch_id)
         assert 3 == evg_cli_service.add_module_to_patch.call_count
 
 


### PR DESCRIPTION
We used to finalize patch after create a new patch and add modules in evergreen. This workflow works in MacOS. However, it doesn't work as expected in Linux. A finalized patch would not able to be configured, ie [this](https://spruce.mongodb.com/version/620572b83e8e865b729836b5/changes?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC). In order to make sure users can configure the tasks in the patch, we decide to not finalize patch after patch being created.