### PR TITLE
DAG-1698 Allow user to specify remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.3 - 2022-03-23
+- Allow user to overwrite remote.
+
 ## 1.1.2 - 2022-03-17
 - Set upstream when pushing a branch.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.1.3 - 2022-03-23
-- Allow user to overwrite remote.
+- Allow user to specify remote.
 
 ## 1.1.2 - 2022-03-17
 - Set upstream when pushing a branch.

--- a/emm-docs/content/subcommands/pull-request.md
+++ b/emm-docs/content/subcommands/pull-request.md
@@ -6,16 +6,16 @@ weight: 16
 {{< hint warning >}}
 **Note**\
 In order to create pull requests in github, you need to sure the `gh` command line tool
-is available and authentication to github is configured. See 
+is available and authentication to github is configured. See
 [Github authentication]({{< ref "/getting-started/installation#github-authentication" >}})
 for details.
 {{< /hint >}}
 
-The `pull-request` subcommand will create pull requests across the base repo and all enabled 
-modules.  
+The `pull-request` subcommand will create pull requests across the base repo and all enabled
+modules.
 
-After local changes have been committed in all repos, you can create the pull request from the base 
-repo, and all enabled modules with changes will create a separate pull request. Each pull 
+After local changes have been committed in all repos, you can create the pull request from the base
+repo, and all enabled modules with changes will create a separate pull request. Each pull
 request will have comments that contain links for all other modules' pull requests.
 
 To create pull requests in base repo and all enabled modules:
@@ -30,4 +30,11 @@ you must also provide a `--title`.
 
 ```bash
 $ evg-module-manager pull-request --title "my pull request title" --body "my pull request body"
+```
+
+By default, the pull request would be pushed against to remote 'origin'. In case where user's
+origin points to `mongodb/mongo`, the `--remote` option can be specified.
+
+```bash
+$ evg-module-manager pull-request --remote "my pull request remote name"
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evg-module-manager"
-version = "1.1.2"
+version = "1.1.3"
 description = "Manage Evergreen modules locally."
 authors = ["Dev Prod DAG <dev-prod-dag@mongodb.com>"]
 license = "Apache-2.0"

--- a/src/emm/emm_cli.py
+++ b/src/emm/emm_cli.py
@@ -225,7 +225,11 @@ def list_modules(ctx: click.Context, enabled: bool, show_details: bool) -> None:
 @cli.command(context_settings=dict(max_content_width=100))
 @click.option("--title", help="Title for the pull request.")
 @click.option("--body", help="Body for the pull request")
-@click.option("--remote", prompt="Please specify the remote you want push to. ie. origin")
+@click.option(
+    "--remote",
+    default="origin",
+    help="Remote to push against for the pull request. The default would be 'origin'",
+)
 @click.pass_context
 def pull_request(
     ctx: click.Context, title: Optional[str], body: Optional[str], remote: str
@@ -237,7 +241,7 @@ def pull_request(
 
     A pull request will be created for the base repository and any enabled modules that contain
     changes. Additionally, a comment will be added to each pull request with links to the other
-    pull requests.
+    pull requests. To specify a remote to push against, `--remote` option can be used.
 
     By default, the commit info will be used to fill out the title and body of the pull request,
     however, the `--title` and `--body` options can be used to customize these.

--- a/src/emm/emm_cli.py
+++ b/src/emm/emm_cli.py
@@ -88,14 +88,14 @@ class EmmOrchestrator:
                 print(f"\trepo: {module_data.repo}")
                 print(f"\tbranch: {module_data.branch}")
 
-    def create_pull_request(self, title: Optional[str], body: Optional[str]) -> None:
+    def create_pull_request(self, title: Optional[str], body: Optional[str], remote: str) -> None:
         """
         Create pull requests in any repositories that contain changes.
 
         :param title: Title for the pull request.
         :param body: Body for the pull request.
         """
-        created_pull_requests = self.pull_request_service.create_pull_request(title, body)
+        created_pull_requests = self.pull_request_service.create_pull_request(title, body, remote)
         print("Created the following pull requests:")
         for pr in created_pull_requests:
             print(f"- {pr.name}: {pr.link}")
@@ -225,8 +225,11 @@ def list_modules(ctx: click.Context, enabled: bool, show_details: bool) -> None:
 @cli.command(context_settings=dict(max_content_width=100))
 @click.option("--title", help="Title for the pull request.")
 @click.option("--body", help="Body for the pull request")
+@click.option("--remote", prompt="Please specify the remote you want push to. ie. origin")
 @click.pass_context
-def pull_request(ctx: click.Context, title: Optional[str], body: Optional[str]) -> None:
+def pull_request(
+    ctx: click.Context, title: Optional[str], body: Optional[str], remote: str
+) -> None:
     """
     Create a Github pull request for changes in the base repository and any enabled modules.
 
@@ -249,7 +252,7 @@ def pull_request(ctx: click.Context, title: Optional[str], body: Optional[str]) 
         )
 
     orchestrator = inject.instance(EmmOrchestrator)
-    orchestrator.create_pull_request(title, body)
+    orchestrator.create_pull_request(title, body, remote)
 
 
 @cli.command(context_settings=dict(max_content_width=100))

--- a/src/emm/services/pull_request_service.py
+++ b/src/emm/services/pull_request_service.py
@@ -68,7 +68,6 @@ class PullRequestService:
         """
         repositories = self.modules_service.collect_repositories()
         changed_repos = [repo for repo in repositories if self.repo_has_changes(repo)]
-
         self.push_changes_to_origin(changed_repos)
         pr_arguments = self.create_pr_arguments(title, body)
         pr_links = self.create_prs(changed_repos, pr_arguments)
@@ -83,6 +82,7 @@ class PullRequestService:
         :param changed_repos: List of repos to push.
         """
         for repo in changed_repos:
+            self.git_service.check_remote(repo.directory)
             self.git_service.push_branch_to_remote(repo.directory)
 
     def create_prs(

--- a/src/emm/services/pull_request_service.py
+++ b/src/emm/services/pull_request_service.py
@@ -1,5 +1,4 @@
 """Service for creating pull requests."""
-from dataclasses import dataclass
 from typing import Dict, List, NamedTuple, Optional
 
 import inject
@@ -33,8 +32,7 @@ class PullRequest(NamedTuple):
         return f"* [{self.name}]({self.link})"
 
 
-@dataclass
-class PullRequestOption:
+class PullRequestOption(NamedTuple):
     """
     Options for creating a pull request.
 
@@ -45,9 +43,9 @@ class PullRequestOption:
     """
 
     title: str
+    body: str
     branch: str
     remote_url: str
-    body: str = "''"
 
     def option_list(self) -> List[str]:
         """Convert pull request arguements to arguement lists."""
@@ -205,23 +203,6 @@ class PullRequestService:
         """
         pr_links = "\n".join([pr.pr_comment() for pr in pr_list if pr.name != name])
         return f"{PR_PREFIX}\n{pr_links}"
-
-    @staticmethod
-    def create_pr_arguments(title: Optional[str], body: Optional[str]) -> List[str]:
-        """
-        Determine the arguments to pass to the gh cli command.
-
-        :param title: Title for pull request.
-        :param body: Body for pull request.
-        :return: List of arguments to pass to gh cli command.
-        """
-        if title is None:
-            return ["--fill"]
-
-        if body is None:
-            body = "''"
-
-        return ["--title", title, "--body", body]
 
     def repo_has_changes(self, repo: Repository) -> bool:
         """Check if the given repository has changes that would indicate a PR should be made."""

--- a/tests/emm/clients/test_git_proxy.py
+++ b/tests/emm/clients/test_git_proxy.py
@@ -607,19 +607,33 @@ class TestDetermineRemote:
         with pytest.raises(UsageError):
             git_proxy.determine_remote(remote, test_path)
 
+
+class TestGetRemoteUrl:
     @patch(ns("local"))
     @patch(ns("Path"))
-    def test_determine_remote_should_raise_error_if_push_to_protected_remote(
+    def test_get_remote_url_should_raise_error_if_push_to_protected_remote(
         self, path_mock, local_mock, git_proxy, mock_git
     ):
-        test_path = make_fake_path()
-        path_mock.return_value = test_path
-        current_remotes = "remote.10gen 10gen_url\nremote.origin.mongodb mongodb/mongo.git\n"
-        mock_git.__getitem__.return_value.return_value = current_remotes
+        current_remotes = ["remote.10gen 10gen_url", "remote.origin.mongodb mongodb/mongo.git"]
         remote = "origin"
 
         with pytest.raises(UsageError):
-            git_proxy.determine_remote(remote, test_path)
+            git_proxy.get_remote_url(remote, current_remotes)
+
+    @patch(ns("local"))
+    @pytest.mark.parametrize(
+        "remote, current_remotes, expected_url",
+        [
+            ("origin", ["remote.10gen 10gen_url", "remote.origin origin_url"], "origin_url"),
+            ("origin", ["remote.other other_url"], None),
+        ],
+    )
+    def test_get_remote_url_should_return_remote_url_if_find(
+        self, local_mock, git_proxy, remote, current_remotes, expected_url
+    ):
+        url = git_proxy.get_remote_url(remote, current_remotes)
+
+        assert url == expected_url
 
 
 class TestDetermineDirectory:

--- a/tests/emm/clients/test_git_proxy.py
+++ b/tests/emm/clients/test_git_proxy.py
@@ -547,6 +547,63 @@ class TestPushBranchToRemote:
         local_mock.cwd.assert_called_with(path)
 
 
+class TestDetermineOverwrittenRemote:
+    @patch(ns("local"))
+    @patch(ns("Path"))
+    def test_current_remote_should_return_remote_name(
+        self, path_mock, local_mock, git_proxy, mock_git
+    ):
+        test_path = make_fake_path()
+        path_mock.return_value = test_path
+        mock_git.__getitem__.return_value.return_value = "remote\n"
+
+        diff = git_proxy.current_remote(test_path)
+
+        mock_git.assert_git_call(["config", "remote.origin.url"])
+        assert diff == "remote"
+
+    @patch(ns("local"))
+    @patch(ns("Path"))
+    def test_remote_contain_mongodb_should_be_overwritten(
+        self, path_mock, local_mock, git_proxy, mock_git
+    ):
+        test_path = make_fake_path()
+        path_mock.return_value = test_path
+        mock_git.__getitem__.return_value.return_value = "mongodb\n"
+
+        should_overwritten = git_proxy.determine_remote_overwritten(test_path)
+
+        assert should_overwritten is True
+
+    @patch(ns("local"))
+    @patch(ns("Path"))
+    def test_remote_contain_mongodb_should_not_be_overwritten(
+        self, path_mock, local_mock, git_proxy, mock_git
+    ):
+        test_path = make_fake_path()
+        path_mock.return_value = test_path
+        mock_git.__getitem__.return_value.return_value = "10gen\n"
+
+        should_overwritten = git_proxy.determine_remote_overwritten(test_path)
+
+        assert should_overwritten is False
+
+    @patch(ns("local"))
+    @patch(ns("Path"))
+    def test_overwritten_remote_should_successful_update_remote(
+        self, path_mock, local_mock, git_proxy, mock_git
+    ):
+        test_path = make_fake_path()
+        path_mock.return_value = test_path
+        mock_git.__getitem__.return_value.return_value = "10gen\n"
+
+        remote = git_proxy.overwrite_remote(test_path)
+
+        mock_git.assert_git_call(["config", "remote.origin.pushurl", "10gen"])
+
+        assert remote == "10gen"
+
+
 class TestDetermineDirectory:
     @patch(ns("local"))
     def test_directory_of_none_should_return_cwd(self, local_mock, git_proxy):

--- a/tests/emm/clients/test_git_proxy.py
+++ b/tests/emm/clients/test_git_proxy.py
@@ -547,7 +547,7 @@ class TestPushBranchToRemote:
         local_mock.cwd.assert_called_with(path)
 
 
-class TestDetermineOverwrittenRemote:
+class TestDetermineRemote:
     @patch(ns("local"))
     @patch(ns("Path"))
     def test_current_remote_should_return_remote_name(
@@ -559,49 +559,21 @@ class TestDetermineOverwrittenRemote:
 
         diff = git_proxy.current_remote(test_path)
 
-        mock_git.assert_git_call(["config", "remote.origin.url"])
-        assert diff == "remote"
+        mock_git.assert_git_call(["remote", "-v"])
+        assert diff == ["remote"]
 
     @patch(ns("local"))
     @patch(ns("Path"))
-    def test_remote_contain_mongodb_should_be_overwritten(
-        self, path_mock, local_mock, git_proxy, mock_git
-    ):
-        test_path = make_fake_path()
-        path_mock.return_value = test_path
-        mock_git.__getitem__.return_value.return_value = "mongodb\n"
-
-        should_overwritten = git_proxy.determine_remote_overwritten(test_path)
-
-        assert should_overwritten is True
-
-    @patch(ns("local"))
-    @patch(ns("Path"))
-    def test_remote_contain_mongodb_should_not_be_overwritten(
+    def test_on_other_remote_option_should_return_nothing(
         self, path_mock, local_mock, git_proxy, mock_git
     ):
         test_path = make_fake_path()
         path_mock.return_value = test_path
         mock_git.__getitem__.return_value.return_value = "10gen\n"
 
-        should_overwritten = git_proxy.determine_remote_overwritten(test_path)
+        should_overwritten = git_proxy.determine_remote(test_path)
 
-        assert should_overwritten is False
-
-    @patch(ns("local"))
-    @patch(ns("Path"))
-    def test_overwritten_remote_should_successful_update_remote(
-        self, path_mock, local_mock, git_proxy, mock_git
-    ):
-        test_path = make_fake_path()
-        path_mock.return_value = test_path
-        mock_git.__getitem__.return_value.return_value = "10gen\n"
-
-        remote = git_proxy.overwrite_remote(test_path)
-
-        mock_git.assert_git_call(["config", "remote.origin.pushurl", "10gen"])
-
-        assert remote == "10gen"
+        assert should_overwritten == "origin"
 
 
 class TestDetermineDirectory:

--- a/tests/emm/clients/test_git_proxy.py
+++ b/tests/emm/clients/test_git_proxy.py
@@ -600,11 +600,25 @@ class TestDetermineRemote:
     ):
         test_path = make_fake_path()
         path_mock.return_value = test_path
-        current_remotes = "remote.10gen 10gen_url\nremote.mongodb mongodb_url\n"
+        current_remotes = "remote.10gen 10gen_url\nremote.tester tester_url\n"
         mock_git.__getitem__.return_value.return_value = current_remotes
         remote = "origin"
 
-        with pytest.raises(ValueError):
+        with pytest.raises(UsageError):
+            git_proxy.determine_remote(remote, test_path)
+
+    @patch(ns("local"))
+    @patch(ns("Path"))
+    def test_determine_remote_should_raise_error_if_push_to_protected_remote(
+        self, path_mock, local_mock, git_proxy, mock_git
+    ):
+        test_path = make_fake_path()
+        path_mock.return_value = test_path
+        current_remotes = "remote.10gen 10gen_url\nremote.origin.mongodb mongodb/mongo.git\n"
+        mock_git.__getitem__.return_value.return_value = current_remotes
+        remote = "origin"
+
+        with pytest.raises(UsageError):
             git_proxy.determine_remote(remote, test_path)
 
 

--- a/tests/emm/services/test_pull_request_service.py
+++ b/tests/emm/services/test_pull_request_service.py
@@ -80,6 +80,18 @@ class TestCreatePullRequest:
         assert github_service.pr_comment.call_count == 3
 
 
+class TestUpdateRemote:
+    def test_all_push_remote_should_not_be_mongodb(
+        self, pull_request_service: under_test.PullRequestService, git_service: GitProxy
+    ):
+        n_repos = 4
+        changed_repos = [build_mock_repository(i) for i in range(n_repos)]
+
+        pull_request_service.update_remote_if_need(changed_repos)
+
+        assert git_service.overwrite_remote.call_count == n_repos
+
+
 class TestPushChangesToOrigin:
     def test_all_repositories_should_have_their_changes_pushed(
         self, pull_request_service: under_test.PullRequestService, git_service: GitProxy

--- a/tests/emm/services/test_pull_request_service.py
+++ b/tests/emm/services/test_pull_request_service.py
@@ -173,21 +173,6 @@ class TestCreateComment:
                 assert pr.link in pr_comment
 
 
-class TestCreatePrArguments:
-    @pytest.mark.parametrize(
-        "title,body,arguments",
-        [
-            (None, None, ["--fill"]),
-            ("my title", None, ["--title", "my title", "--body", "''"]),
-            ("my title", "my body", ["--title", "my title", "--body", "my body"]),
-        ],
-    )
-    def test_arguments_should_work_correctly(
-        self, title, body, arguments, pull_request_service: under_test.PullRequestService
-    ):
-        assert pull_request_service.create_pr_arguments(title, body) == arguments
-
-
 class TestCombinePRArugments:
     @pytest.mark.parametrize(
         "title,body,remote,arguments",


### PR DESCRIPTION
Since plumbum.local would directly output the shell result and click cannot interactively ask user to select the remote in that case. I make the workflow similar to our other functions, let user specify options if they want to change the remote. 

`emm pull request`  -> `remote.origin not mongodb/mongo and have changes` -> `create pull request`
          |
          ---> `remote.origin is mongodb/mongo and have changes` -> `provide warning & error out, ask usr to specify remote`

`emm pull request --remote 'other_remote_name'` -> `remote exits` -> `create pull request`
                    |
                    ----> `remote not exists` -> `error out and provide available remote urls`