### PR TITLE
DAG-1959 Add '--local' option to 'git branch-update' subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.0 - 2022-08-22
+- Add `--local` option to `git branch-update` subcommand.
+
 ## 1.1.8 - 2022-08-15
 - Cache the results of `evergreen evaluate` when creating a new branch.
 

--- a/emm-docs/content/subcommands/git-branch-update.md
+++ b/emm-docs/content/subcommands/git-branch-update.md
@@ -1,15 +1,38 @@
 ---
 weight: 8
 ---
-Use the `git branch-update` subcommand to update your current branch with the changes made remotely. 
+Use the `git branch-update` subcommand to update your current branch with the changes made remotely.
 
-The `git branch-update` subcommand will: 
+The `git branch-update` subcommand will:
 * fetch the latest changes from the origin of all the repositories.
+* update base local branch with the latest changes, if requested.
 * update your branch with the latest changes in the base repository.
 * update all enabled modules up to the change associated with where the base repository was updated to.
 
+The `-b`/`--branch` option allows you to specify the base branch, `--local` option can be used if you
+are specifying a local base branch rather than remote, `--rebase` option allows to rebase on top of
+changes rather than merge changes in.
+
+Updating local base branch and merge changes in on your branch:
+
 ```bash
-$ evg-module-manager git branch-update
+$ evg-module-manager git branch-update --branch master --local
 Base: updated to latest 'master'
+- enterprise: 07c4792479f85fb8af129a87ee6e116c4b7d7808
+```
+
+Updating local base branch and rebase your branch on top of it:
+
+```bash
+$ evg-module-manager git branch-update --branch master --local --rebase
+Base: updated to latest 'master'
+- enterprise: 07c4792479f85fb8af129a87ee6e116c4b7d7808
+```
+
+Updating with remote base branch:
+
+```bash
+$ evg-module-manager git branch-update --branch origin/master
+Base: updated to latest 'origin/master'
 - enterprise: 07c4792479f85fb8af129a87ee6e116c4b7d7808
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evg-module-manager"
-version = "1.1.8"
+version = "1.2.0"
 description = "Manage Evergreen modules locally."
 authors = ["Dev Prod DAG <dev-prod-dag@mongodb.com>"]
 license = "Apache-2.0"

--- a/src/emm/cli/git_cli.py
+++ b/src/emm/cli/git_cli.py
@@ -129,14 +129,15 @@ class GitOrchestrator:
         for module in modules:
             rprint(f" - [yellow]{module}[/yellow]")
 
-    def update_branch(self, branch: str, rebase: bool) -> None:
+    def update_branch(self, branch: str, local: bool, rebase: bool) -> None:
         """
         Pull in changes from the specified branch.
 
         :param branch: Branch to pull changes from.
+        :param local: If True, update base local branch, else do nothing.
         :param rebase: If True, rebase on top of changes, else merge changes in.
         """
-        modules = self.git_branch_service.update_branch(branch, rebase)
+        modules = self.git_branch_service.update_branch(branch, local, rebase)
         rprint(f"[yellow]Base[/yellow]: updated to latest '{branch}'")
         for module in modules:
             rprint(f"- [yellow]{module.module_name}[/yellow]: {module.output}")
@@ -258,6 +259,7 @@ def branch_pull(ctx: click.Context, rebase: bool) -> None:
 
 @git_cli.command(context_settings=dict(max_content_width=100))
 @click.option("-b", "--branch", type=str, required=True, help="Branch to pull updates from.")
+@click.option("--local", is_flag=True, default=False, help="Update base local branch.")
 @click.option(
     "--rebase",
     is_flag=True,
@@ -265,12 +267,12 @@ def branch_pull(ctx: click.Context, rebase: bool) -> None:
     help="Rebase on top of any changes instead of merging changes.",
 )
 @click.pass_context
-def branch_update(ctx: click.Context, branch: str, rebase: bool) -> None:
+def branch_update(ctx: click.Context, branch: str, local: bool, rebase: bool) -> None:
     """Get the latest changes from remote repositories and update the current branch with them."""
     validation_service = inject.instance(ValidationService)
     validation_service.validate_git_command()
     orchestrator = inject.instance(GitOrchestrator)
-    orchestrator.update_branch(branch, rebase)
+    orchestrator.update_branch(branch, local, rebase)
 
 
 @git_cli.command(context_settings=dict(max_content_width=100))

--- a/src/emm/cli/git_cli.py
+++ b/src/emm/cli/git_cli.py
@@ -134,7 +134,7 @@ class GitOrchestrator:
         Pull in changes from the specified branch.
 
         :param branch: Branch to pull changes from.
-        :param local: If True, update base local branch, else do nothing.
+        :param local: Indicate whether the branch is local, otherwise remote.
         :param rebase: If True, rebase on top of changes, else merge changes in.
         """
         modules = self.git_branch_service.update_branch(branch, local, rebase)

--- a/src/emm/clients/git_proxy.py
+++ b/src/emm/clients/git_proxy.py
@@ -43,13 +43,16 @@ class GitProxy:
         with local.cwd(self._determine_directory(directory)):
             self.git[args]()
 
-    def fetch(self, directory: Optional[Path] = None) -> None:
+    def fetch(self, directory: Optional[Path] = None, branch: Optional[str] = None) -> None:
         """
         Fetch commit from origin.
 
         :param directory: Path to root of repo to operate on.
+        :param branch: Local branch to update.
         """
         args = ["fetch", "origin"]
+        if branch is not None:
+            args.append(f"{branch}:{branch}")
         with local.cwd(self._determine_directory(directory)):
             self.git[args]()
 

--- a/src/emm/services/git_branch_service.py
+++ b/src/emm/services/git_branch_service.py
@@ -88,7 +88,7 @@ class GitBranchService:
         Update the current branch with commits from the given branch.
 
         :param branch: Branch to get updates from.
-        :param local: If True, update base local branch, else do nothing.
+        :param local: Indicate whether the branch is local, otherwise remote.
         :param rebase: If True, rebase on top of changes, else merge changes in.
         :return: List of what commit each module was checked out to.
         """

--- a/src/emm/services/git_branch_service.py
+++ b/src/emm/services/git_branch_service.py
@@ -83,17 +83,21 @@ class GitBranchService:
 
         return [repo.name for repo in repository_list]
 
-    def update_branch(self, branch: str, rebase: bool) -> List[GitCommandOutput]:
+    def update_branch(self, branch: str, local: bool, rebase: bool) -> List[GitCommandOutput]:
         """
         Update the current branch with commits from the given branch.
 
         :param branch: Branch to get updates from.
+        :param local: If True, update base local branch, else do nothing.
         :param rebase: If True, rebase on top of changes, else merge changes in.
         :return: List of what commit each module was checked out to.
         """
         repository_list = self.modules_service.collect_repositories()
         for repo in repository_list:
-            self.git_proxy.fetch(directory=repo.directory)
+            if local:
+                self.git_proxy.fetch(directory=repo.directory, branch=branch)
+            else:
+                self.git_proxy.fetch(directory=repo.directory)
 
         if rebase:
             self.git_proxy.rebase(branch)

--- a/tests/emm/clients/test_git_proxy.py
+++ b/tests/emm/clients/test_git_proxy.py
@@ -66,6 +66,18 @@ class TestFetch:
         local_mock.cwd.assert_called_with(test_path)
 
     @patch(ns("local"))
+    @patch(ns("Path"))
+    def test_fetch_should_call_git_fetch_with_base_local_branch_update(
+        self, path_mock, local_mock, git_proxy, mock_git
+    ):
+        test_path = make_fake_path()
+        path_mock.return_value = test_path
+        git_proxy.fetch(branch="master")
+
+        mock_git.assert_git_call(["fetch", "origin", "master:master"])
+        local_mock.cwd.assert_called_with(test_path)
+
+    @patch(ns("local"))
     def test_fetch_with_directory_should_call_git_fetch_from_dir(
         self, local_mock, git_proxy, mock_git
     ):


### PR DESCRIPTION
It could be replaced with the `--remote` option with the opposite meaning, if we think that preferable default behavior is to work with a local base branch.